### PR TITLE
Delete unnecessary code from enum parse

### DIFF
--- a/codegen-v2/src/codegen/dart/mod.rs
+++ b/codegen-v2/src/codegen/dart/mod.rs
@@ -5,12 +5,12 @@
 use self::functions::process_methods;
 use self::inits::process_inits;
 use self::properties::process_properties;
+use crate::codegen::dart::utils::pretty_name;
 use crate::manifest::{DeinitInfo, FileInfo, ParamInfo, ProtoInfo, TypeInfo, TypeVariant};
 use crate::{Error, Result};
 use handlebars::Handlebars;
 use serde_json::json;
 use std::fmt::Display;
-use crate::codegen::dart::utils::pretty_name;
 
 mod functions;
 mod inits;
@@ -48,8 +48,6 @@ pub struct DartEnum {
     add_description: bool,
     variants: Vec<DartEnumVariant>,
     value_type: String,
-    value_field: Option<String>,
-    constructor: Option<String>,
 }
 
 /// Represents a Swift enum variant.
@@ -281,15 +279,9 @@ fn param_c_ffi_call(param: &ParamInfo) -> Option<DartOperation> {
 
             // If the parameter is nullable, add special handler.
             if param.ty.is_nullable {
-                DartOperation::CallOptional {
-                    var_name,
-                    call,
-                }
+                DartOperation::CallOptional { var_name, call }
             } else {
-                DartOperation::Call {
-                    var_name,
-                    call,
-                }
+                DartOperation::Call { var_name, call }
             }
         }
         TypeVariant::Data => {
@@ -300,15 +292,9 @@ fn param_c_ffi_call(param: &ParamInfo) -> Option<DartOperation> {
 
             // If the parameter is nullable, add special handler.
             if param.ty.is_nullable {
-                DartOperation::CallOptional {
-                    var_name,
-                    call,
-                }
+                DartOperation::CallOptional { var_name, call }
             } else {
-                DartOperation::Call {
-                    var_name,
-                    call,
-                }
+                DartOperation::Call { var_name, call }
             }
         }
         // E.g.
@@ -319,18 +305,12 @@ fn param_c_ffi_call(param: &ParamInfo) -> Option<DartOperation> {
             // `CallOptional` handler but rather use the question mark
             // operator.
             let (var_name, call) = if param.ty.is_nullable {
-                (
-                    param.name.clone(),
-                    format!("{}?.rawValue", param.name),
-                )
+                (param.name.clone(), format!("{}?.rawValue", param.name))
             } else {
                 (param.name.clone(), format!("{}.rawValue", param.name))
             };
 
-            DartOperation::Call {
-                var_name,
-                call,
-            }
+            DartOperation::Call { var_name, call }
         }
         // E.g. `final param = TWSomeEnum(rawValue: param.rawValue);`
         // Note that it calls the constructor of the enum, which calls
@@ -357,15 +337,9 @@ fn param_c_ffi_defer_call(param: &ParamInfo) -> Option<DartOperation> {
             );
 
             if param.ty.is_nullable {
-                DartOperation::DeferOptionalCall {
-                    var_name,
-                    call,
-                }
+                DartOperation::DeferOptionalCall { var_name, call }
             } else {
-                DartOperation::DeferCall {
-                    var_name,
-                    call,
-                }
+                DartOperation::DeferCall { var_name, call }
             }
         }
         TypeVariant::Data => {
@@ -375,15 +349,9 @@ fn param_c_ffi_defer_call(param: &ParamInfo) -> Option<DartOperation> {
             );
 
             if param.ty.is_nullable {
-                DartOperation::DeferOptionalCall {
-                    var_name,
-                    call,
-                }
+                DartOperation::DeferOptionalCall { var_name, call }
             } else {
-                DartOperation::DeferCall {
-                    var_name,
-                    call,
-                }
+                DartOperation::DeferCall { var_name, call }
             }
         }
         _ => return None,

--- a/codegen-v2/src/codegen/dart/render.rs
+++ b/codegen-v2/src/codegen/dart/render.rs
@@ -166,7 +166,6 @@ pub fn generate_dart_types(mut info: FileInfo) -> Result<GeneratedDartTypes> {
             None
         };
 
-
         let mut imports = vec![];
         for super_class in superclasses.clone() {
             imports.push(import_name(super_class.as_str()));
@@ -189,13 +188,6 @@ pub fn generate_dart_types(mut info: FileInfo) -> Result<GeneratedDartTypes> {
 
     // Render enums.
     for enm in info.enums {
-        let obj = ObjectVariant::Enum(&enm.name);
-
-        // Process items.
-        let (methods, properties);
-        (methods, info.functions) = process_methods(&obj, info.functions)?;
-        (properties, info.properties) = process_properties(&obj, info.properties)?;
-
         // Convert the name into an appropriate format.
         let pretty_enum_name = pretty_name(enm.name);
 
@@ -218,8 +210,6 @@ pub fn generate_dart_types(mut info: FileInfo) -> Result<GeneratedDartTypes> {
 
         //TODO: get value type from info.value
         let value_type = "int";
-        let value_field = Some(format!("final {} value;", value_type));
-        let constructor = Some(format!("const {}(this.value);", pretty_enum_name));
 
         // Add the generated Dart code to the outputs
         outputs.enums.push(DartEnum {
@@ -228,20 +218,6 @@ pub fn generate_dart_types(mut info: FileInfo) -> Result<GeneratedDartTypes> {
             add_description: add_class,
             variants,
             value_type: value_type.to_string(),
-            value_field,
-            constructor,
-        });
-
-        // Avoid rendering empty extension for enums.
-        if methods.is_empty() && properties.is_empty() {
-            continue;
-        }
-
-        outputs.extensions.push(DartEnumExtension {
-            name: pretty_enum_name,
-            init_instance: true,
-            methods,
-            properties,
         });
     }
 

--- a/codegen-v2/src/codegen/dart/templates/enum.hbs
+++ b/codegen-v2/src/codegen/dart/templates/enum.hbs
@@ -16,12 +16,8 @@ String get description => switch (value) {
   {{this.value}} => '{{this.as_string}}',
   {{/each}}
 {{/if}}
-{{#if value_field}}
   final {{value_type}} value;
-{{/if}}
-{{#if constructor}}
   const {{name}}(this.value);
-{{/if}}
 
   static {{#unless is_public}}_{{/unless}}{{name}} fromValue({{value_type}} value) => switch (value) {
       {{#each variants}}


### PR DESCRIPTION
chore: delete unnecessary code from enum parse